### PR TITLE
Get some shell from busybox base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN tar xf v${GRCOV_VERSION}.tar.gz \
     grep '^/' | \
     xargs -I % cp --parents % deps
 
-FROM scratch
+FROM busybox
 
 ARG GRCOV_VERSION
 


### PR DESCRIPTION
Running in CI may require some shell. Use busybox as a minimal base image. 